### PR TITLE
Adding support to specify a location for cancelled TV.

### DIFF
--- a/api_show.rb
+++ b/api_show.rb
@@ -36,23 +36,10 @@ def add_show(tvdbid)
   search_json['seasons'] = search_results['seasons']
   search_json['ProfileId'] = @show_profile_id
 
-  # check if @show_cancelled_different_location is defined or set to false
-  # if set to true, set the rootFolderPath to @show_cancelled_location
+  # Set the rootFolderPath for the show based on settings
   rootFolder = JSON.parse(api_query("rootfolder", ""))[0]['path']
-
-  if @show_cancelled_different_location then
-    if defined?(@show_cancelled_location) then
-      if search_results['status'] == "ended" then
-        search_json['rootFolderPath'] = "#{@show_cancelled_location}"
-      else
-        search_json['rootFolderPath'] = "#{rootFolder}"
-      end
-    else
-      search_json['rootFolderPath'] = "#{rootFolder}"
-    end
-  else
-    search_json['rootFolderPath'] = "#{rootFolder}"
-  end
+  search_json['rootFolderPath'] = "#{rootFolder}" if ! @show_cancelled_different_location | (@show_cancelled_different_location || ! defined? (@show_cancelled_location))
+  search_json['rootFolderPath'] = "#{@show_cancelled_location}" if @show_cancelled_different_location and defined?(@show_cancelled_location)
 
   #Get album art from search_results
   album_art_url = search_results['remotePoster']

--- a/api_show.rb
+++ b/api_show.rb
@@ -37,8 +37,7 @@ def add_show(tvdbid)
   search_json['ProfileId'] = @show_profile_id
 
   # Set the rootFolderPath for the show based on settings
-  rootFolder = JSON.parse(api_query("rootfolder", ""))[0]['path']
-  search_json['rootFolderPath'] = "#{rootFolder}" if ! @show_cancelled_different_location | (@show_cancelled_different_location || ! defined?(@show_cancelled_location))
+  search_json['rootFolderPath'] = JSON.parse(api_query("rootfolder", ""))[0]['path'] if ! @show_cancelled_different_location | (@show_cancelled_different_location || ! defined?(@show_cancelled_location))
   search_json['rootFolderPath'] = "#{@show_cancelled_location}" if @show_cancelled_different_location and defined?(@show_cancelled_location)
 
   #Get album art from search_results

--- a/api_show.rb
+++ b/api_show.rb
@@ -38,7 +38,7 @@ def add_show(tvdbid)
 
   # Set the rootFolderPath for the show based on settings
   rootFolder = JSON.parse(api_query("rootfolder", ""))[0]['path']
-  search_json['rootFolderPath'] = "#{rootFolder}" if ! @show_cancelled_different_location | (@show_cancelled_different_location || ! defined? (@show_cancelled_location))
+  search_json['rootFolderPath'] = "#{rootFolder}" if ! @show_cancelled_different_location | (@show_cancelled_different_location || ! defined?(@show_cancelled_location))
   search_json['rootFolderPath'] = "#{@show_cancelled_location}" if @show_cancelled_different_location and defined?(@show_cancelled_location)
 
   #Get album art from search_results

--- a/api_show.rb
+++ b/api_show.rb
@@ -14,7 +14,7 @@ def search_show(title)
   shows = Array.new
   results.each do |r|
     if ! r[:tvdbId].nil?
-      shows.insert(-1, { :tvdbid => r[:tvdbId], :title => r[:title], :year => r[:year], :downloaded => search_show_local(r[:tvdbId]),:season_count => r[:seasons].count})
+      shows.insert(-1, { :tvdbid => r[:tvdbId], :title => r[:title], :year => r[:year], :status => r[:status], :downloaded => search_show_local(r[:tvdbId]),:season_count => r[:seasons].count})
     end
   end
 
@@ -34,8 +34,25 @@ def add_show(tvdbid)
   search_json['titleSlug'] = search_results['titleSlug']
   search_json['images'] = search_results['images']
   search_json['seasons'] = search_results['seasons']
-  search_json['rootFolderPath'] = JSON.parse(api_query("rootfolder", ""))[0]['path']
   search_json['ProfileId'] = @show_profile_id
+
+  # check if @show_cancelled_different_location is defined or set to false
+  # if set to true, set the rootFolderPath to @show_cancelled_location
+  rootFolder = JSON.parse(api_query("rootfolder", ""))[0]['path']
+
+  if @show_cancelled_different_location then
+    if defined?(@show_cancelled_location) then
+      if search_results['status'] == "ended" then
+        search_json['rootFolderPath'] = "#{@show_cancelled_location}"
+      else
+        search_json['rootFolderPath'] = "#{rootFolder}"
+      end
+    else
+      search_json['rootFolderPath'] = "#{rootFolder}"
+    end
+  else
+    search_json['rootFolderPath'] = "#{rootFolder}"
+  end
 
   #Get album art from search_results
   album_art_url = search_results['remotePoster']

--- a/commands.rb
+++ b/commands.rb
@@ -46,17 +46,13 @@ def process_command_s(message)
   else
     options = [ ]
     results.each do |s|
-      if s[:season_count] == 1 then
-        button_text = "#{s[:title]} (#{s[:year]}) - #{s[:season_count]} Season"
-      else
-        button_text = "#{s[:title]} (#{s[:year]}) - #{s[:season_count]} Seasons"
-      end
+      button_text = "#{s[:title]} (#{s[:year]}) - #{s[:season_count]} Seasons"
+      button_text = "#{s[:title]} (#{s[:year]}) - #{s[:season_count]} Season" if s[:season_count] == 1
+
+      # prepend a '-' if the show has ended
+      button_text = "- " + button_text if s[:status] == "ended"
 
       callback_data = "DLS|#{s[:tvdbid]}"
-
-      if s[:status] == "ended" then
-        button_text = "- " + button_text
-      end
       
       if s[:downloaded] == true then
         button_text = "* " + button_text

--- a/commands.rb
+++ b/commands.rb
@@ -46,8 +46,17 @@ def process_command_s(message)
   else
     options = [ ]
     results.each do |s|
-      button_text = "#{s[:title]} (#{s[:year]}) - #{s[:season_count]} Seasons" 
+      if s[:season_count] == 1 then
+        button_text = "#{s[:title]} (#{s[:year]}) - #{s[:season_count]} Season"
+      else
+        button_text = "#{s[:title]} (#{s[:year]}) - #{s[:season_count]} Seasons"
+      end
+
       callback_data = "DLS|#{s[:tvdbid]}"
+
+      if s[:status] == "ended" then
+        button_text = "- " + button_text
+      end
       
       if s[:downloaded] == true then
         button_text = "* " + button_text
@@ -66,6 +75,7 @@ def process_command_s(message)
 
     message_text = "#{message.from.username}What show(s) would you like?\n\n"
     message_text += "Shows prepended with '+' will need to be downloaded by an admin due to their size\n"
+    message_text += "Shows prepended with '-' are no longer a continuing series.\n"
     message_text += "Ask @#{@admin_username} to approve these items.\n\n"
     message_text += "Shows prepended with '*' have already been requested\n"
     send_question(message.chat.id, message_text, options)

--- a/commands.rb
+++ b/commands.rb
@@ -71,7 +71,7 @@ def process_command_s(message)
 
     message_text = "#{message.from.username}What show(s) would you like?\n\n"
     message_text += "Shows prepended with '+' will need to be downloaded by an admin due to their size\n"
-    message_text += "Shows prepended with '-' are no longer a continuing series.\n"
+    message_text += "Shows prepended with '-' are no longer airing shows.\n"
     message_text += "Ask @#{@admin_username} to approve these items.\n\n"
     message_text += "Shows prepended with '*' have already been requested\n"
     send_question(message.chat.id, message_text, options)

--- a/settings.rb-example
+++ b/settings.rb-example
@@ -17,7 +17,9 @@
 @show_port = <sonarr_port> #port Sonarr is listening on
 @show_context = "" #if Sonarr is at 1.2.3.4/sonarr/ or some other context
 @show_api_key = "<sonarr_api_key>"
-@show_profile_id = "<sonarr_quality_profile_id>" 
+@show_profile_id = "<sonarr_quality_profile_id>"
+@show_cancelled_different_location = false # If you want cancelled TV to go to a folder different from the default, you want this to be true. 
+@show_cancelled_location = "/your/file/path" # If the above is true, specify a location. If you do not, it will use the default.
 @show_timeout = 10
 @season_admin_cutoff = 10 #More than x season shows need to be downloaded by admin
 


### PR DESCRIPTION
This pull request will implement support to specify a alternate location for Cancelled TV series. 

Changelog: 
 - Added a field into the results array for "status". This value is generated from the Sonarr api if the series is continuing, ended, etc.
 - Added two more values to settings.rb called @show_cancelled_different_location, @show_cancelled_location. If these values aren't specified in the settings.rb, it will continue to perform the same way it always has (using the default rootFolderPath provided by the Sonarr API). This may be able to be modified to use other paths listed in the Sonarr API endpoint for rootFolder, maybe just a [1] instead of a [0]? 
 - Altered the button_text to be "season" instead of "seasons" when the season count is "1".
 - Altered the button_text to have a "-" on shows that are in a "ended" status.