### PR TITLE
Adding the addOptions array to support newer versions of Sonarr.

### DIFF
--- a/api_show.rb
+++ b/api_show.rb
@@ -36,6 +36,11 @@ def add_show(tvdbid)
   search_json['seasons'] = search_results['seasons']
   search_json['rootFolderPath'] = JSON.parse(api_query("rootfolder", ""))[0]['path']
   search_json['ProfileId'] = @show_profile_id
+  search_json['addOptions'] = { 
+    "ignoreEpisodesWithFiles": false,
+    "ignoreEpisodesWithoutFiles": false,
+    "searchForMissingEpisodes": true
+  }
 
   #Get album art from search_results
   album_art_url = search_results['remotePoster']


### PR DESCRIPTION
Due to newer versions of Sonarr only monitoring episodes newer than 14 days, I'm submitting this patch to let PlexBot continue working as intended. 

I also confirmed it works in older versions with this code (for example, version 2.0.0.5338).

The addOptions array is suggested by the Sonarr wiki in the POST section: https://github.com/Sonarr/Sonarr/wiki/Series